### PR TITLE
allow empty yaml (ie: --- which results in nil map, not {}) during merge

### DIFF
--- a/clconf/clconf.go
+++ b/clconf/clconf.go
@@ -420,8 +420,13 @@ func UnmarshalYaml(yamlStrings ...string) (map[interface{}]interface{}, error) {
 
 	result := make(map[interface{}]interface{})
 	for _, y := range allYamls {
+		if y == nil {
+			// a yaml that is `---` only, is _valid_ (passes yaml lint) but will
+			// be <nil>.  mergo.Merge does not like <nil>
+			continue
+		}
 		if err := mergo.Merge(&result, y, mergo.WithOverride); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("yaml merge failed: %v", err)
 		}
 	}
 	return result, nil

--- a/clconf/clconf_test.go
+++ b/clconf/clconf_test.go
@@ -833,7 +833,16 @@ func TestToKvMap(t *testing.T) {
 		}, "numeric keys")
 }
 
-func TestUnmarshallSingleYaml(t *testing.T) {
+func TestUnmarshalSingleYaml(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		yamlObj, err := clconf.UnmarshalSingleYaml("---")
+		if err != nil {
+			t.Errorf("failed to unmarshal; %v", err)
+		}
+		if yamlObj != nil {
+			t.Errorf("expected <nil> for empty `---`, got %T: %v", yamlObj, yamlObj)
+		}
+	})
 	t.Run("string", func(t *testing.T) {
 		yamlObj, err := clconf.UnmarshalSingleYaml("foo")
 		if err != nil {
@@ -879,11 +888,20 @@ func TestUnmarshallSingleYaml(t *testing.T) {
 }
 
 func TestUnmarshalYaml(t *testing.T) {
-	expected, _ := clconf.UnmarshalYaml(configMapAndSecrets)
-	merged, err := clconf.UnmarshalYaml(configMap, secrets)
-	if err != nil || !reflect.DeepEqual(merged, expected) {
-		t.Errorf("ConfigMap and Secrets failed: [%v] != [%v]", expected, merged)
-	}
+	t.Run("empty", func(t *testing.T) {
+		expected := map[interface{}]interface{}{}
+		actual, err := clconf.UnmarshalYaml("---")
+		if err != nil || !reflect.DeepEqual(actual, expected) {
+			t.Errorf("ConfigMap and Secrets failed: [%v] != [%v]", expected, actual)
+		}
+	})
+	t.Run("configMapAndSecrets", func(t *testing.T) {
+		expected, _ := clconf.UnmarshalYaml(configMapAndSecrets)
+		actual, err := clconf.UnmarshalYaml(configMap, secrets)
+		if err != nil || !reflect.DeepEqual(actual, expected) {
+			t.Errorf("ConfigMap and Secrets failed: [%v] != [%v]", expected, actual)
+		}
+	})
 }
 
 func TestUnmarshalYamlMultipleDocs(t *testing.T) {


### PR DESCRIPTION
Allow empty yaml:
```yaml
---
```
during merge.  This type of file passes yamllint (so valid yaml) but is different from:
```yaml
---
{}
```
The former results in `<nil>` when parsed, the later `map[interface{}]interface{}{}`.

This PR will treat both the same during merge in that neither will _fail_ the merge, nor have any effect on the merge.