### PR TITLE
Add support for alternate template delimiters

### DIFF
--- a/clconf/in_memory_template.go
+++ b/clconf/in_memory_template.go
@@ -13,6 +13,8 @@ import (
 type TemplateConfig struct {
 	Prefix      string
 	SecretAgent *SecretAgent
+	LeftDelim   string
+	RightDelim  string
 }
 
 // Template is a wrapper for template.Template to include custom template
@@ -91,7 +93,10 @@ func NewTemplate(name, text string, config *TemplateConfig) (*Template, error) {
 		addCryptFuncs(funcMap, config.SecretAgent)
 	}
 
-	tmpl, err := template.New(name).Funcs(funcMap).Parse(text)
+	tmpl, err := template.New(name).
+		Delims(config.LeftDelim, config.RightDelim).
+		Funcs(funcMap).
+		Parse(text)
 	if err != nil {
 		return nil, fmt.Errorf("unable to process template %s: %s", name, err)
 	}

--- a/clconf/in_memory_template.go
+++ b/clconf/in_memory_template.go
@@ -93,7 +93,8 @@ func NewTemplate(name, text string, config *TemplateConfig) (*Template, error) {
 		addCryptFuncs(funcMap, config.SecretAgent)
 	}
 
-	tmpl, err := template.New(name).
+	tmpl, err := template.
+		New(name).
 		Delims(config.LeftDelim, config.RightDelim).
 		Funcs(funcMap).
 		Parse(text)

--- a/clconf/template.go
+++ b/clconf/template.go
@@ -34,6 +34,10 @@ type TemplateOptions struct {
 	// Extension is the extension to use when searching folders. If missing all files will be used.
 	// The extension is stripped from the file name when templating.
 	Extension string
+	// LeftDelim is passed to go teplate.Delims
+	LeftDelim string
+	// RightDelim is passed to go teplate.Delims
+	RightDelim string
 }
 
 type pathWithRelative struct {
@@ -117,6 +121,8 @@ func processTemplate(paths pathWithRelative, dest string, value interface{},
 	template, err := NewTemplateFromFile(paths.rel, paths.full,
 		&TemplateConfig{
 			SecretAgent: secretAgent,
+			LeftDelim:   options.LeftDelim,
+			RightDelim:  options.RightDelim,
 		})
 	if err != nil {
 		return result, err

--- a/cmd/getv_test.go
+++ b/cmd/getv_test.go
@@ -192,3 +192,30 @@ func TestGetTemplate(t *testing.T) {
 	}
 	testGetTemplate(t, "template file", "bar", data, context)
 }
+
+func TestGetTemplateDelims(t *testing.T) {
+	keyFile := path.Join("..", "testdata", "test.secring.gpg")
+
+	tempDir, err := ioutil.TempDir("", "clconf")
+	if err != nil {
+		t.Fatalf("Unable to create temp dir: %v", err)
+	}
+	defer func() {
+		os.RemoveAll(tempDir)
+	}()
+
+	data := map[interface{}]interface{}{"foo": "bar"}
+	templateString := "<< getv \"/foo\" >>"
+
+	context := getvContext{
+		rootContext: &rootContext{
+			secretKeyring: *newOptionalString(keyFile, true),
+		},
+		Marshaler: Marshaler{
+			templateString: *newOptionalString(templateString, true),
+			leftDelim:      "<<",
+			rightDelim:     ">>",
+		},
+	}
+	testGetTemplate(t, "template string", "bar", data, context)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,8 @@ type rootContext struct {
 	secretKeyring       optionalString
 	secretKeyringBase64 optionalString
 	stdin               bool
+	leftDelim           string
+	rightDelim          string
 	vars                []string
 	yaml                []string
 	yamlBase64          []string

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,8 +16,6 @@ type rootContext struct {
 	secretKeyring       optionalString
 	secretKeyringBase64 optionalString
 	stdin               bool
-	leftDelim           string
-	rightDelim          string
 	vars                []string
 	yaml                []string
 	yamlBase64          []string

--- a/cmd/template.go
+++ b/cmd/template.go
@@ -92,6 +92,16 @@ copy from source template).`)
 		"flatten",
 		false,
 		"Don't preserve relative folders when processing a source folder.")
+	cmd.Flags().StringVar(
+		&c.templateOptions.LeftDelim,
+		"left-delimiter",
+		"{{",
+		"Delimiter to use when parsing templates for substitutions")
+	cmd.Flags().StringVar(
+		&c.templateOptions.RightDelim,
+		"right-delimiter",
+		"}}",
+		"Delimiter to use when parsing templates for substitutions")
 
 	return cmd
 }

--- a/cmd/template_test.go
+++ b/cmd/template_test.go
@@ -34,3 +34,33 @@ func TestTemplateCmd(t *testing.T) {
 		t.Errorf("Content of %q was not as expected, %q != %q", resultPath, actual, expected)
 	}
 }
+
+func TestTemplateCmdDelims(t *testing.T) {
+	temp, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("Error making temp folder %v", err)
+	}
+	defer os.RemoveAll(temp)
+
+	testDataPath := filepath.Join("..", "testdata")
+	cmd := rootCmd()
+	cmd.SetArgs([]string{"template",
+		"--yaml", filepath.Join(testDataPath, "testconfig.yml"),
+		"--left-delimiter", "<<",
+		"--right-delimiter", ">>",
+		testDataPath, temp})
+
+	if err = cmd.Execute(); err != nil {
+		t.Errorf("Execute failed: %v", err)
+	}
+
+	resultPath := filepath.Join(temp, "testtemplatedelims.txt")
+	actual, err := ioutil.ReadFile(resultPath)
+	if err != nil {
+		t.Errorf("Error reading %q: %v", resultPath, err)
+	}
+	expected := "db.pastdev.com"
+	if string(actual) != expected {
+		t.Errorf("Content of %q was not as expected, %q != %q", resultPath, actual, expected)
+	}
+}

--- a/testdata/testtemplatedelims.txt.clconf
+++ b/testdata/testtemplatedelims.txt.clconf
@@ -1,0 +1,1 @@
+<< getv "/app/db/hostname" >>


### PR DESCRIPTION
Adds `--left-delimiter` and `--right-delimiter` for template operations to alter the template delimiter.