### PR TITLE
Handle fetching integer and boolean keys when given a string key

### DIFF
--- a/pkg/core/clconf.go
+++ b/pkg/core/clconf.go
@@ -71,11 +71,42 @@ func GetValue(conf interface{}, keyPath string) (interface{}, error) {
 			// yaml deserialized
 			var ok bool
 			value, ok = typed[part]
-			if !ok {
-				return nil, fmt.Errorf(
-					"value at [%v] does not exist",
-					currentPath)
+			if ok {
+				continue
 			}
+			intKey, err := strconv.ParseInt(part, 10, 64)
+			if err == nil {
+				value, ok = typed[int(intKey)]
+				if ok {
+					continue
+				}
+				value, ok = typed[int8(intKey)]
+				if ok {
+					continue
+				}
+				value, ok = typed[int16(intKey)]
+				if ok {
+					continue
+				}
+				value, ok = typed[int32(intKey)]
+				if ok {
+					continue
+				}
+				value, ok = typed[int64(intKey)]
+				if ok {
+					continue
+				}
+			}
+			boolKey, err := strconv.ParseBool(part)
+			if err == nil {
+				value, ok = typed[boolKey]
+				if ok {
+					continue
+				}
+			}
+			return nil, fmt.Errorf(
+				"value at [%v] does not exist",
+				currentPath)
 		case []interface{}:
 			i, err := strconv.Atoi(part)
 			if err != nil {

--- a/pkg/core/clconf_test.go
+++ b/pkg/core/clconf_test.go
@@ -191,9 +191,8 @@ func TestGetValue(t *testing.T) {
 			if errExpected {
 				require.Error(t, err)
 				return
-			} else {
-				require.NoError(t, err)
 			}
+			require.NoError(t, err)
 			require.Equal(t, expected, actual)
 		})
 	}


### PR DESCRIPTION
Pretty much every interaction with getv will be a string path (e.g. /foo/bar), even when it contains numbers like /foo/123/bip. When unmarshalling yaml, however, the data structure stores their real types. When looking up in the map it will never find the string version of the keys. This change searches the map for the integer and boolean versions of the key to ensure we find integer keys.

We should probably rewrite the yaml maps to be map[string]any just like json, which would solve this problem from the source without the need for these shenanigans, but that's a larger effort.